### PR TITLE
joeferraro/MavensMate#838

### DIFF
--- a/src/mavensmate/projectSettings.ts
+++ b/src/mavensmate/projectSettings.ts
@@ -17,7 +17,7 @@ export class ProjectSettings {
         if(projectPath && !ProjectSettings._instances[projectPath]){
             let settingsPath = buildSettingsPath(projectPath);
             console.info(`Retrieving settings at path:  ${ settingsPath }`);
-            ProjectSettings._instances[projectPath] = file.open(settingsPath);            
+            ProjectSettings._instances[projectPath] = file.open(settingsPath);
         }
 
         return ProjectSettings._instances[projectPath];
@@ -28,7 +28,7 @@ export class ProjectSettings {
         if(!ProjectSettings._instances[projectPath]){
             ProjectSettings.getProjectSettings(projectPath);
         }
-        return ProjectSettings._instances[projectPath] !== null;
+        return ProjectSettings._instances[projectPath] != null;
     }
 }
 


### PR DESCRIPTION
 Fixed null check (was failing when value === undefined), which would cause blank workspace to be handled as an existing project.

This was pretty much preventing users without existing projects open from doing anything (as mavensmate would fail to activate)