### PR TITLE
Add ability to refresh folders from Salesforce

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,10 @@
                 "title": "MavensMate: Refresh File"
             },
             {
+                "command": "mavensmate.refreshFolder",
+                "title": "MavensMate: Refresh Folder"
+            },
+            {
                 "command": "mavensmate.openMetadata",
                 "title": "MavensMate: Open File In Salesforce"
             },
@@ -327,6 +331,11 @@
                 {
                     "when": "resourceLangId == 'xml'",
                     "command": "mavensmate.refreshFile",
+                    "group": "mavensmate"
+                },
+                {
+                    "when": "explorerResourceIsFolder",
+                    "command": "mavensmate.refreshFolder",
                     "group": "mavensmate"
                 },
                 {

--- a/src/mavensmate/commands/refreshFolder.ts
+++ b/src/mavensmate/commands/refreshFolder.ts
@@ -1,0 +1,30 @@
+import { PathsCommand } from './pathsCommand';
+
+import * as vscode from 'vscode';
+
+module.exports = class RefreshFolder extends PathsCommand {
+    static create(){
+        return new RefreshFolder();
+    }
+
+    constructor() {
+        super('Refresh Folder', 'refresh-metadata');
+        this.async = true;
+        this.body.args.ui = false;
+    }
+
+    protected confirmPath(): Thenable<any> {
+        return super.confirmPath().then(() => this.promptForConfirmation());
+    }
+
+    private promptForConfirmation(){
+        let confirmMessage = `Are you sure you want to refresh ${ this.baseName } from Salesforce?`;
+        return vscode.window.showInformationMessage(confirmMessage, 'Yes').then((answer) => {
+            if(answer === 'Yes'){
+                return Promise.resolve();
+            } else {
+                return Promise.reject('Refresh File Cancelled');
+            }
+        });
+    }
+}


### PR DESCRIPTION
A first cut at allowing entire folders to be refreshed from Salesforce. Needs some context checking so it can only be used in certain (src) folders, but it works in this form.