### PR TITLE
Fix tests so they are compatible with POSIX as well as Windows systems

### DIFF
--- a/test/mavensmate/mavensMateAppConfig.test.ts
+++ b/test/mavensmate/mavensMateAppConfig.test.ts
@@ -1,5 +1,6 @@
 import assert = require('assert');
 import sinon = require('sinon');
+import path = require('path');
 
 import operatingSystem = require('../../src/workspace/operatingSystem');
 import jsonFile = require('../../src/workspace/jsonFile');
@@ -23,8 +24,8 @@ suite('mavensMate App Config', () => {
         process.env.HOME = 'hometest';
         
         openStub = sinon.stub(jsonFile, 'open');
-        openStub.withArgs('userprofiletest/.mavensmate-config.json').returns(windowsJson);
-        openStub.withArgs('hometest/.mavensmate-config.json').returns(nonWindowsJson); 
+        openStub.withArgs(path.normalize('userprofiletest/.mavensmate-config.json')).returns(windowsJson);
+        openStub.withArgs(path.normalize('hometest/.mavensmate-config.json')).returns(nonWindowsJson); 
     });
     
     teardown(() => { 
@@ -43,8 +44,8 @@ suite('mavensMate App Config', () => {
         test('it uses home', () => {
             mavensMateAppConfig.getConfig();
             
-            sinon.assert.calledWith(openStub, 'hometest/.mavensmate-config.json');
-            sinon.assert.neverCalledWith(openStub, 'userprofiletest/.mavensmate-config.json');
+            sinon.assert.calledWith(openStub, path.normalize('hometest/.mavensmate-config.json'));
+            sinon.assert.neverCalledWith(openStub, path.normalize('userprofiletest/.mavensmate-config.json'));
         });
         
         test('it parses correct json', () => {
@@ -70,8 +71,8 @@ suite('mavensMate App Config', () => {
         test('it uses userprofile', () => {
             mavensMateAppConfig.getConfig();
             
-            sinon.assert.calledWith(openStub, 'userprofiletest/.mavensmate-config.json');
-            sinon.assert.neverCalledWith(openStub, 'hometest/.mavensmate-config.json');
+            sinon.assert.calledWith(openStub, path.normalize('userprofiletest/.mavensmate-config.json'));
+            sinon.assert.neverCalledWith(openStub, path.normalize('hometest/.mavensmate-config.json'));
         });
         
         test('it parses correct json', () => {
@@ -97,8 +98,8 @@ suite('mavensMate App Config', () => {
         test('it uses home', () => {
             mavensMateAppConfig.getConfig();
             
-            sinon.assert.calledWith(openStub, 'hometest/.mavensmate-config.json');
-            sinon.assert.neverCalledWith(openStub, 'userprofiletest/.mavensmate-config.json');
+            sinon.assert.calledWith(openStub, path.normalize('hometest/.mavensmate-config.json'));
+            sinon.assert.neverCalledWith(openStub, path.normalize('userprofiletest/.mavensmate-config.json'));
         });
         
         test('it parses correct json', () => {

--- a/test/workspace/projectList.test.ts
+++ b/test/workspace/projectList.test.ts
@@ -1,6 +1,7 @@
 import assert = require('assert');
 import sinon = require('sinon');
 import fs = require('fs-promise');
+import path = require('path');
 
 import jsonFile = require('../../src/workspace/jsonFile');
 import { ProjectSettings } from '../../src/mavensmate/projectSettings';
@@ -35,11 +36,11 @@ suite('projectList', () => {
         readDirStub.withArgs('missingWorkspace').returns(Promise.reject('missingWorkspace is missing as intended'));
         
         jsonFileStub = sinon.stub(jsonFile, 'open');
-        jsonFileStub.withArgs('workspace1/project1/config/.settings').returns(testSettings);
-        jsonFileStub.withArgs('workspace1/project2/config/.settings').returns(testSettings);
-        jsonFileStub.withArgs('workspace2/project1/config/.settings').returns(testSettings);
-        jsonFileStub.withArgs('workspace2/project3/config/.settings').returns(testSettings);
-        jsonFileStub.withArgs('workspace2/doesNotExist/config/.settings').returns(null);
+        jsonFileStub.withArgs(path.normalize('workspace1/project1/config/.settings')).returns(testSettings);
+        jsonFileStub.withArgs(path.normalize('workspace1/project2/config/.settings')).returns(testSettings);
+        jsonFileStub.withArgs(path.normalize('workspace2/project1/config/.settings')).returns(testSettings);
+        jsonFileStub.withArgs(path.normalize('workspace2/project3/config/.settings')).returns(testSettings);
+        jsonFileStub.withArgs(path.normalize('workspace2/doesNotExist/config/.settings')).returns(null);
     });
     
     teardown(() => {
@@ -51,10 +52,10 @@ suite('projectList', () => {
     test('gets the 4 actual projects', (testDone) => {
         projectList.promiseList().then((projects) => {
                 assert.equal(projects.length, 4);
-                assertIsProject(projects[0], 'project1', 'workspace1/project1', 'workspace1');
-                assertIsProject(projects[1], 'project2', 'workspace1/project2', 'workspace1');
-                assertIsProject(projects[2], 'project1', 'workspace2/project1', 'workspace2');
-                assertIsProject(projects[3], 'project3', 'workspace2/project3', 'workspace2');
+                assertIsProject(projects[0], 'project1', path.normalize('workspace1/project1'), 'workspace1');
+                assertIsProject(projects[1], 'project2', path.normalize('workspace1/project2'), 'workspace1');
+                assertIsProject(projects[2], 'project1', path.normalize('workspace2/project1'), 'workspace2');
+                assertIsProject(projects[3], 'project3', path.normalize('workspace2/project3'), 'workspace2');
             })
             .done(testDone, console.error);
     });


### PR DESCRIPTION
The original version of these tests couldn't pass on a Windows PC due to the slashes going the wrong direction. This fixes it, so the tests can pass on both POSIX and Windows platforms.